### PR TITLE
Fix configure script when the which command isn't available

### DIFF
--- a/configure
+++ b/configure
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+set -e
+
 # default values
 ocamlbuild=`which ocamlbuild || echo '/usr/local/bin/ocamlbuild'`
 bin_path=`dirname $ocamlbuild`


### PR DESCRIPTION
If `which` isn't available the configure script would succeed but misconfigure